### PR TITLE
Minor version update: 0.1.0 to 0.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "jordanbrauer/cronitor-php",
   "description": "A small wrapper object for Cronitor.io cron job monitoring service.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "plugin",
   "license": "MIT",
   "authors": [
@@ -14,7 +14,7 @@
     "tests": "phpunit --configuration='./phpunit.xml' --test-suffix='.spec.php' --color=always ./tests/"
   },
   "require": {
-    "php": ">=7.0.1"
+    "php": ">=7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7f31956e9566426d4823992e9503ac2a",
-    "content-hash": "ec480b4cf2a2d6f1f93bd6f05823085e",
+    "hash": "410391750acb5f06d7f5156a78c68ae7",
+    "content-hash": "d19c891549cc06489724bd269c8044b5",
     "packages": [],
     "packages-dev": [
         {
@@ -1464,7 +1464,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.0"
+        "php": ">=7.0"
     },
     "platform-dev": []
 }

--- a/src/Cronitor/Monitor.php
+++ b/src/Cronitor/Monitor.php
@@ -43,9 +43,8 @@ class Monitor
    */
   public function run (string $message = null)
   {
-    return $message ??
-      $this->ping("run", ["msg" => $message]) ??
-      $this->ping("run");
+    if ($message) return $this->ping("run", ["msg" => $message]);
+    return $this->ping("run");
   }
 
   /**
@@ -55,9 +54,8 @@ class Monitor
    */
   public function complete (string $message = null)
   {
-    return $message ??
-      $this->ping("complete", ["msg" => $message]) ??
-      $this->ping("complete");
+    if ($message) return $this->ping("complete", ["msg" => $message]);
+    return $this->ping("complete");
   }
 
   /**
@@ -65,11 +63,10 @@ class Monitor
    * @method fail
    * @param string $message An optional message to be passed to Cronitor with a max char length of 2048.
    */
-  public function fail (string $message = null)
+    public function fail (string $message = null)
   {
-    return $message ??
-      $this->ping("fail", ["msg" => $message]) ??
-      $this->ping("fail");
+    if ($message) return $this->ping("fail", ["msg" => $message]);
+    return $this->ping("fail");
   }
 
   /**

--- a/src/Cronitor/Monitor.php
+++ b/src/Cronitor/Monitor.php
@@ -10,13 +10,13 @@ class Monitor
 
   /**
    * @param string $monitorId The unique identifier for your monitor found on Cronitors' dashboard.
-   * @param array $opts An array of options to be passed to the monitor on construction (e.g., auth_key).
+   * @param array $options An array of options to be passed to the monitor on construction (e.g., auth_key).
    */
-  public function __construct (string $monitorId, array $opts = [])
+  public function __construct (string $monitorId, array $options = [])
   {
     $this->monitorId = $monitorId;
-    $this->authKey = $opts["auth_key"] ?? "";
-    $this->baseUrl = $opts["base_url"] ?? "https://cronitor.link";
+    $this->authKey = $options["auth_key"] ?? "";
+    $this->baseUrl = $options["base_url"] ?? "https://cronitor.link";
   }
 
   /**

--- a/src/Cronitor/Monitor.php
+++ b/src/Cronitor/Monitor.php
@@ -8,6 +8,10 @@ class Monitor
   protected $authKey;
   protected $baseUrl;
 
+  /**
+   * @param string $monitorId The unique identifier for your monitor found on Cronitors' dashboard.
+   * @param array $opts An array of options to be passed to the monitor on construction (e.g., auth_key).
+   */
   public function __construct (string $monitorId, array $opts = [])
   {
     $this->monitorId = $monitorId;
@@ -17,7 +21,7 @@ class Monitor
 
   /**
    * Ping a Cronitor endpoint with optional parameters.
-   * @method ping
+   *
    * @param string $endpoint A valid Cronitor endpoint to be pinged (see Cronitor docs for info).
    * @param array $parameters An array of URL query string parameters that will be appended to the ping.
    */
@@ -37,7 +41,7 @@ class Monitor
 
   /**
    * Ping the Cronitor /run endpoint with the ping method.
-   * @method run
+   *
    * @param string $message An optional message to be passed to Cronitor with a max char length of 2048.
    */
   public function run (string $message = null)
@@ -48,7 +52,7 @@ class Monitor
 
   /**
    * Ping the Cronitor /complete endpoint with the ping method.
-   * @method complete
+   *
    * @param string $message An optional message to be passed to Cronitor with a max char length of 2048.
    */
   public function complete (string $message = null)
@@ -59,10 +63,10 @@ class Monitor
 
   /**
    * Ping the Cronitor /fail endpoint with the ping method.
-   * @method fail
+   *
    * @param string $message An optional message to be passed to Cronitor with a max char length of 2048.
    */
-    public function fail (string $message = null)
+  public function fail (string $message = null)
   {
     if ($message) return $this->ping("fail", ["msg" => $message]);
     return $this->ping("fail");
@@ -70,7 +74,7 @@ class Monitor
 
   /**
    * Ping the Cronitor /pause endpoint with the ping method.
-   * @method pause
+   *
    * @param integer $duration A duration in hours to pause the monitor for (see Cronitor docs for more info).
    */
   public function pause (int $duration)
@@ -80,7 +84,6 @@ class Monitor
 
   /**
    * Ping the Cronitor /pause endpoint with a duration of 0 to unpause the monitor.
-   * @method resume
    */
   public function resume ()
   {

--- a/src/Cronitor/Monitor.php
+++ b/src/Cronitor/Monitor.php
@@ -32,7 +32,6 @@ class Monitor
       $queryString = http_build_query($parameters)
       and $url .= "?{$queryString}";
 
-    // echo $url.PHP_EOL;
     return file_get_contents($url);
   }
 


### PR DESCRIPTION
* Shortened ping methods from 3 lines to 2 for better readability.
* Renamed  `$opts` param to `$options` less ambiguity (even though _opts_ means options).
* Remove old unused debugging comment.
* Updated method comments and their formatting